### PR TITLE
IV hotfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ Get current network config:
 this.$erdjs.dapp.getNetworkConfig()
 ```
 
+Logout current user/wallet:
+```
+this.$erdjs.dapp.logout()
+```
+
 Get Pinia stores:
 `getDappStore`, `getAccountStore`, `getLoginInfoStore`, `getNotificationsStore`, `getProviderStore`, `getToastsStore`, `getTransactionsStore`, `getTransactionsInfoStore`; Probably you'll not need all of them, but it's good to have them available.
 
@@ -105,4 +110,31 @@ Few examples on how to use Pinia getters to retrieve user/account data:
 - get login method `this.$erdjs.dapp.getLoginInfoStore().getLoginMethod` (extension, walletconnect, etc)
 
 
-To be updated...
+## Login card component
+Display login card components in your app:
+```
+<ErdjsLoginCard class="my-4">
+    <template #title><h4 class="mb-3 text-center text-primary">Web 3.0 Login</h4></template>
+    <template #description><p class="text-center">Sign in with MultiversX wallet.</p></template>
+    <template #extension>Extension</template>
+    <template #ledger>Ledger</template>
+    <template #webwallet>Web Wallet</template>
+    <template #maiarapp>Maiar App</template>
+</ErdjsLoginCard>
+```
+
+
+## Explorer links
+If you need to build explorer links, there are 2 methods available: `explorerUrlBuilder` and `getExplorerLink`
+
+Working example:
+```
+import { explorerUrlBuilder, getExplorerLink } from "erdjs-vue";
+
+const to = explorerUrlBuilder.accountDetails(erdjs.dapp.getAccountStore().address);
+
+return getExplorerLink({
+    explorerAddress: String(erdjs.dapp.getNetworkConfig().explorerAddress),
+    to: to
+});
+```

--- a/erdjs-vue/Dapp.ts
+++ b/erdjs-vue/Dapp.ts
@@ -20,6 +20,7 @@ import { transactionSender } from 'erdjs-vue/hooks/transactions/transactionsSend
 import { ref, watch } from "vue";
 import { sendSignedTransactions } from 'erdjs-vue/apiCalls/transactions';
 import { useToastsStore } from './store/erdjsToasts';
+import { logout as logoutAction } from 'erdjs-vue/utils/logout'
 
 export interface DappType {
   init: void,
@@ -133,5 +134,12 @@ export default class Dapp {
         errorMessage: ''
       }
     });
+  }
+
+  logout(
+    callbackUrl?: string,
+    onRedirect?: (callbackUrl?: string) => void
+  ) {
+    logoutAction(callbackUrl, onRedirect);
   }
 }

--- a/erdjs-vue/ErdjsVue.ts
+++ b/erdjs-vue/ErdjsVue.ts
@@ -43,6 +43,7 @@ export function erdjsVue(options: ErdjsVueOptions = defaultOptions): ErdjsVue {
       }
 
       app.config.globalProperties.$erdjs = this;
+      app.provide('erdjs', this)
 
       setTimeout(() => {
         useTransactionsTracker();

--- a/erdjs-vue/components/ErdjsLoginCard/component.vue
+++ b/erdjs-vue/components/ErdjsLoginCard/component.vue
@@ -2,26 +2,26 @@
     <div>
         <template v-if="!isLoggedIn">
             <template v-if="!loginMethod">
-                <h4>Login</h4>
-                <p class="mb-4">Select login method</p>
+                <slot name="title"><h4>{{ title }}</h4></slot>
+                <slot name="description"><p class="mb-4">{{ description }}</p></slot>
                 
                 <div class="login-method d-flex flex-column flex-md-row justify-content-between flex-wrap">
                     <button 
                         @click.prevent="(loginMethod = getLoginMethods().extension)"
                         class="m-2 btn btn-primary"
-                    >Extension</button>
+                    ><slot name="extension">{{ buttonTextExtension }}</slot></button>
                     <!-- <button 
                         @click.prevent="(loginMethod = getLoginMethods().ledger)"
                         class="m-2 btn btn-primary"
-                    >Ledger</button> -->
+                    ><slot name="ledger">{{ buttonTextLedger }}</slot></button> -->
                     <button 
                         @click.prevent="(loginMethod = getLoginMethods().wallet)"
                         class="m-2 btn btn-primary"
-                    >Web Wallet</button>
+                    ><slot name="webwallet">{{ buttonTextWebWallet }}</slot></button>
                     <button 
                         @click.prevent="(loginMethod = getLoginMethods().walletconnect)"
                         class="m-2 btn btn-primary"
-                    >Maiar</button>
+                    ><slot name="maiarapp">{{ buttonTextMaiarApp }}</slot></button>
                 </div>
             </template>
             <template v-if="loginMethod === getLoginMethods().extension">
@@ -36,10 +36,10 @@
             </template>
         </template>
         <template v-if="isLoggedIn">
-            <p>Your address</p>
-            <div class="mb-4"><a :href="getExplorerUrl" target="_blank">{{ getAddress }}</a></div>
-            <div>
-                <button @click.prevent="logout()" class="btn btn-secondary">Logout</button>
+            <p class="text-center">MultiversX address: <strong>{{ getAddressShort }}</strong></p>
+            <div class="d-flex flex-row justify-content-center">
+                <a :href="getExplorerUrl" target="_blank" class="btn btn-outline-secondary mx-2">View in explorer</a>
+                <button @click.prevent="logout()" class="btn btn-outline-secondary mx-2">Logout</button>
             </div>
         </template>
     </div>
@@ -51,8 +51,6 @@ import { ErdjsLoginExtension } from 'erdjs-vue/components/ErdjsLoginExtension'
 import { ErdjsLoginWebWallet } from 'erdjs-vue/components/ErdjsLoginWebWallet'
 import { ErdjsLoginWalletConnect } from 'erdjs-vue/components/ErdjsLoginWalletConnect'
 import { logout } from 'erdjs-vue/utils/logout'
-import { tryAuthenticateWalletUser } from 'erdjs-vue/hooks/login/useWebWalletLogin'
-import { setExtensionProvider } from 'erdjs-vue/hooks/login/useExtensionLogin'
 import { getExplorerUrl, explorerUrlBuilder } from 'erdjs-vue/utils/transactions/getInterpretedTransaction/helpers';
 
 export default {
@@ -65,6 +63,12 @@ export default {
     data() {
         return {
             loginMethod: '',
+            title: 'MultiversX Login',
+            description: '',
+            buttonTextExtension: 'Extension',
+            buttonTextLedger: 'Ledger',
+            buttonTextWebWallet: 'Web Wallet',
+            buttonTextMaiarApp: 'Maiar App'
         }
     },
     computed: {
@@ -78,7 +82,15 @@ export default {
             const to = explorerUrlBuilder.accountDetails(this.getAddress);
 
             return getExplorerUrl(to);
-        }
+        },
+        getAddressShort() {
+            let address = [
+                this.getAddress.substr(0, 6),
+                this.getAddress.substr(this.getAddress.length - 6, 6),
+            ];
+
+            return address.join('....');
+        },
     },
     methods: {
         getLoginMethods() {

--- a/erdjs-vue/components/ErdjsLoginCard/component.vue
+++ b/erdjs-vue/components/ErdjsLoginCard/component.vue
@@ -5,7 +5,7 @@
                 <h4>Login</h4>
                 <p class="mb-4">Select login method</p>
                 
-                <div class="login-method d-flex justify-content-between flex-wrap">
+                <div class="login-method d-flex flex-column flex-md-row justify-content-between flex-wrap">
                     <button 
                         @click.prevent="(loginMethod = getLoginMethods().extension)"
                         class="m-2 btn btn-primary"

--- a/erdjs-vue/components/ErdjsLoginWalletConnect/ErdjsLoginWalletConnect.vue
+++ b/erdjs-vue/components/ErdjsLoginWalletConnect/ErdjsLoginWalletConnect.vue
@@ -1,15 +1,15 @@
 <template>
-    <div class="erdjs-vue__login-wrappper">
+    <div class="erdjs-vue__login-wrappper d-flex flex-column justify-content-start align-items-center">
         <div class="dapp-login__tab-error" v-if="error">
             {{ error }}
         </div>
         <h4>Maiar Login</h4>
         <div v-if="uriDeepLink">
-            <a :href="uriDeepLink" class="btn btn-primary">Click to login</a>
+            <a :href="uriDeepLink" class="btn btn-primary w-100 mb-4">Click to login</a>
         </div>
         <p class="mb-2">Scan the QR Code with Maiar app</p>
-        <div v-html="qrCodeSvg" v-if="qrCodeSvg" class="wallet-connect-qrcode"></div>
-        <div class="back-button">
+        <div v-html="qrCodeSvg" v-if="qrCodeSvg" class="wallet-connect-qrcode px-4"></div>
+        <div class="back-button my-3">
             <button @click.prevent="$emit('hide-login-tab')" class="btn btn-secondary">Back</button>
         </div>
     </div>
@@ -27,7 +27,8 @@ export default {
     data() {
         return {
             error: null,
-            qrCodeSvg: ''
+            qrCodeSvg: '',
+            uriDeepLink: '',
         }
     },
     props: {
@@ -39,6 +40,7 @@ export default {
         }
     },
     mounted() {
+        this.generateQRCode()
         if (this.selectedMode === LoginMethodsEnum.walletconnect) {
             this.login()
         }

--- a/erdjs-vue/main.ts
+++ b/erdjs-vue/main.ts
@@ -1,1 +1,6 @@
-export { erdjsVue } from './ErdjsVue';
+import { erdjsVue } from './ErdjsVue';
+
+import { getExplorerLink } from './utils/transactions/getInterpretedTransaction/helpers/getExplorerLink';
+import { explorerUrlBuilder } from './utils/transactions/getInterpretedTransaction/helpers';
+
+export { erdjsVue, getExplorerLink, explorerUrlBuilder };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "erdjs-vue",
-    "version": "0.9.3",
+    "version": "0.9.4",
     "private": false,
     "description": "A Vue.js library that holds the core functional logic of a dapp on the MultiversX (formerly Elrond)",
     "keywords": [


### PR DESCRIPTION
Curent PR includes various fixes:
- Maiar app login button on mobile devices
- style improvements for login card components
- added logout method that can be called via `this.$erdjs.dapp.logout()`

- added option to change the login card component text via slots
Example:
```
<ErdjsLoginCard class="my-4">
      <template #title><h4 class="mb-3 text-center text-primary">{{ $t('title_web3_login', 'Web 3.0 Login') }}</h4></template>
      <template #description><p class="text-center">{{ $t('multiverx_login_title', 'Sign in with MultiversX wallet.') }}</p></template>
      <template #extension>{{ $t('extension', 'Extension') }}</template>
      <template #ledger>{{ $t('ledger', 'Ledger') }}</template>
      <template #webwallet>{{ $t('webwallet', 'Web Wallet') }}</template>
      <template #maiarapp>{{ $t('maiarapp', 'Maiar App') }}</template>
    </ErdjsLoginCard>
```

- new method available `getExplorerLink` that builds the explorer link for current env (devnet, tesnet, mainnet)
- new method available `explorerUrlBuilder` that builds the correct path for explorer link (account, tx, etc). For more details, check `erdjs-vue/utils/transactions/getInterpretedTransaction/helpers`

Example usage - get link for current account:
```
import { explorerUrlBuilder, getExplorerLink } from "erdjs-vue";

const to = explorerUrlBuilder.accountDetails(erdjs.dapp.getAccountStore().address);

return getExplorerLink({
    explorerAddress: String(erdjs.dapp.getNetworkConfig().explorerAddress),
    to: to
});
```